### PR TITLE
style: defaultContainer 첫번째 요소 height 설정#77

### DIFF
--- a/src/components/defaultContainer/index.tsx
+++ b/src/components/defaultContainer/index.tsx
@@ -7,7 +7,7 @@ interface DefaultContainerProps {
 function DefaultContainer({ children }: DefaultContainerProps) {
   return (
     <div className="shadow-md mx-auto">
-      <div className="flex flex-col w-375 min-w-375 max-w-375 min-h-screen my-0 mx-auto overflow-auto [&>*:first-child]:h-[calc(100vh-53px)] [&>*:first-child]:overflow-auto">
+      <div className="flex flex-col w-375 min-w-375 max-w-375 min-h-screen max-h-screen my-0 mx-auto [&>*:first-child]:h-screen [&>*:first-child]:overflow-auto">
         {children}
       </div>
     </div>


### PR DESCRIPTION
close #77
# 개요
- FooterNavBar가 없을 때 defaultContainer 영역의 height가 전체를 먹지 않는 버그 수정

# 작업 사항
- defaultContainer 하위 첫번째 요소 height 설정