### PR TITLE
Feat/login api redirect paratemer#87

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,6 @@ NEXT_PUBLIC_KAKAO_REDIRECT_URL=http://localhost:3000/member/kakao
 NEXT_PUBLIC_SERVER_API=http://apis.buybye.kr:8080/member/kakao
 
 NEXT_PUBLIC_DOMAIN=http://localhost:3000/
+
+# Login
+NEXT_PUBLIC_LOGIN_REDIRECT_PARAMETER=local

--- a/.env.development
+++ b/.env.development
@@ -5,4 +5,4 @@ NEXT_PUBLIC_SERVER_API=http://apis.buybye.kr:8080/auth/kakao
 NEXT_PUBLIC_DOMAIN=http://www.buybye.kr/
 
 # Login
-NEXT_PUBLIC_LOGIN_REDIRECT_PARAMETER=prod
+NEXT_PUBLIC_LOGIN_REDIRECT_PARAMETER=local

--- a/src/app/member/kakao/page.tsx
+++ b/src/app/member/kakao/page.tsx
@@ -12,7 +12,11 @@ interface LoginResponseType {
 }
 
 export const fetchAuth = (code: string): Promise<LoginResponseType> =>
-  instance.get(`/members/login?code=${code}`);
+  instance.get(`/members/login?code=${code}`, {
+    params: {
+      status: process.env.NEXT_PUBLIC_LOGIN_REDIRECT_PARAMETER
+    }
+  });
 
 export const LoginHandler = (code: string) =>
   fetchAuth(code).then((response: LoginResponseType) => {


### PR DESCRIPTION
close: #87 
# 개요
- 카카오 로그인 api  redirect parameter 설정

# 작업 사항
- get `/members/login` status parameter 설정
  - prod일 시: status -> prod
  - dev일 시: status -> local
